### PR TITLE
alignment with other instrumentations/no new spans

### DIFF
--- a/api/src/main/java/lv/ctco/tpl/rabbitmq/configuration/sleuth/SleuthAMQPMessagePostProcessor.java
+++ b/api/src/main/java/lv/ctco/tpl/rabbitmq/configuration/sleuth/SleuthAMQPMessagePostProcessor.java
@@ -14,7 +14,7 @@ public class SleuthAMQPMessagePostProcessor implements MessagePostProcessor {
 
     @Override
     public Message postProcessMessage(Message message) throws AmqpException {
-        bridge.populateHeaders(message, "sendMessage");
+        bridge.populateHeaders(message);
         return message;
     }
 }

--- a/api/src/main/java/lv/ctco/tpl/rabbitmq/configuration/sleuth/SleuthMessageBridge.java
+++ b/api/src/main/java/lv/ctco/tpl/rabbitmq/configuration/sleuth/SleuthMessageBridge.java
@@ -12,25 +12,31 @@ import java.util.Map;
 @Component
 public class SleuthMessageBridge {
 
-    public static final String TRACE_ID_HIGH_NAME = "X-B3-TraceIdHigh";
-
     @Autowired
     Tracer tracer;
 
-    public void populateHeaders(Message message, String entryPoint) {
-        MessageProperties properties = message.getMessageProperties();
-        Span span;
-        if (tracer.isTracing()) {
-            span = tracer.getCurrentSpan();
-        } else {
-            span = tracer.createSpan(entryPoint);
+    public void populateHeaders(Message message) {
+        if (!tracer.isTracing()) {
+            return;
         }
-        
-        properties.setHeader(Span.SPAN_ID_NAME, span.getSpanId());
-        properties.setHeader(Span.TRACE_ID_NAME, span.getTraceId());
-        properties.setHeader(TRACE_ID_HIGH_NAME, span.getTraceIdHigh());
+
+        MessageProperties properties = message.getMessageProperties();
+        Span span = tracer.getCurrentSpan();
+
+        //Based on FeignRequestInjector implementation
+        Long parentId = getParentId(span);
+        if (parentId != null) {
+            properties.setHeader(Span.PARENT_ID_NAME, Span.idToHex(parentId));
+        }
+
+        properties.setHeader(Span.SPAN_ID_NAME, Span.idToHex(span.getSpanId()));
+        properties.setHeader(Span.TRACE_ID_NAME, span.traceIdString());
         properties.setHeader(Span.PROCESS_ID_NAME, span.getProcessId());
         properties.setHeader(Span.SPAN_NAME_NAME, span.getName());
+    }
+
+    private static Long getParentId(Span span) {
+        return !span.getParents().isEmpty() ? span.getParents().get(0) : null;
     }
 
     public Span setupSpan(Message message, String entryPoint) {
@@ -38,12 +44,30 @@ public class SleuthMessageBridge {
         Map<String, Object> headers = properties.getHeaders();
         Span span;
         if (headers.containsKey(Span.TRACE_ID_NAME)) {
-            span = Span.builder()
-                    .traceId((Long) headers.get(Span.TRACE_ID_NAME))
-                    .traceIdHigh((Long) headers.get(TRACE_ID_HIGH_NAME))
-                    .spanId((Long) headers.get(Span.SPAN_ID_NAME))
-                    .name((String) headers.get(Span.SPAN_NAME_NAME))
-                    .processId((String) headers.get(Span.PROCESS_ID_NAME))
+
+            //based on HeaderBasedMessagingExtractor implementation
+            String traceId = (String) headers.get(Span.TRACE_ID_NAME);
+            Span.SpanBuilder builder = Span.builder();
+
+            Object parentId = headers.get(Span.PARENT_ID_NAME);
+            if (parentId != null) {
+                builder.parent(Span.hexToId((String) parentId));
+            }
+
+            Object processId = headers.get(Span.PROCESS_ID_NAME);
+            if (processId != null) {
+                builder.processId((String) processId);
+            }
+
+            Object spanName = headers.get(Span.SPAN_NAME_NAME);
+            if (spanName != null) {
+                builder.name((String) spanName);
+            }
+
+            span = builder
+                    .traceId(Span.hexToId(traceId))
+                    .traceIdHigh(traceId.length() == 32 ? Span.hexToId(traceId, 0) : 0)
+                    .spanId(Span.hexToId((String) headers.get(Span.SPAN_ID_NAME)))
                     .build();
         } else {
             span = null;

--- a/api/src/test/java/lv/ctco/tpl/rabbitmq/configuration/sleuth/SleuthAMQPMessagePostProcessorTest.java
+++ b/api/src/test/java/lv/ctco/tpl/rabbitmq/configuration/sleuth/SleuthAMQPMessagePostProcessorTest.java
@@ -10,10 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class SleuthAMQPMessagePostProcessorTest extends IntegrationTest {
 
@@ -33,9 +34,10 @@ public class SleuthAMQPMessagePostProcessorTest extends IntegrationTest {
         Span root = tracer.createSpan("root");
         Message message = new Message("hello".getBytes(), new MessageProperties());
         template.send(message);
-        assertThat(message.getMessageProperties().getHeaders().get(Span.TRACE_ID_NAME), is(root.getTraceId()));
-        assertThat(message.getMessageProperties().getHeaders().get(Span.SPAN_ID_NAME), is(root.getSpanId()));
-        assertThat(message.getMessageProperties().getHeaders().get(Span.SPAN_NAME_NAME), is(root.getName()));
+        Map<String, Object> headers = message.getMessageProperties().getHeaders();
+        assertThat(headers.get(Span.TRACE_ID_NAME), is(root.traceIdString()));
+        assertThat(Span.hexToId((String) headers.get(Span.SPAN_ID_NAME)), is(root.getSpanId()));
+        assertThat(headers.get(Span.SPAN_NAME_NAME), is(root.getName()));
 
     }
 
@@ -43,10 +45,9 @@ public class SleuthAMQPMessagePostProcessorTest extends IntegrationTest {
     public void testPopulate_NewSpan() throws Exception {
         Message message = new Message("hello".getBytes(), new MessageProperties());
         template.send(message);
-        assertThat(message.getMessageProperties().getHeaders().get(Span.TRACE_ID_NAME), is(notNullValue()));
-        assertThat(message.getMessageProperties().getHeaders().get(Span.SPAN_ID_NAME), is(notNullValue()));
-        assertThat(message.getMessageProperties().getHeaders().get(Span.SPAN_NAME_NAME), is(notNullValue()));
-
+        Map<String, Object> headers = message.getMessageProperties().getHeaders();
+        assertThat(headers.get(Span.TRACE_ID_NAME), is(nullValue()));
+        assertThat(headers.get(Span.SPAN_ID_NAME), is(nullValue()));
+        assertThat(headers.get(Span.SPAN_NAME_NAME), is(nullValue()));
     }
-
 }


### PR DESCRIPTION
--numeric span headers are replaced with hex values (alignment with existing http clients instrumentation)
--new spans wont be created for outgoing messages (all spans need to be closed at some point)
--test adjustments